### PR TITLE
Add recipe tests for calculate total cost method

### DIFF
--- a/src/Ingredient.js
+++ b/src/Ingredient.js
@@ -1,8 +1,8 @@
 class  Ingredient{
-  constructor(id = 0, name = 'unknown', estimatedCostInCents = 0) {
+  constructor(id = 0, estimatedCostInCents = 0, amount) {
     this.id = id,
     this.name = name,
-    this.estimatedCostInCents = estimatedCostInCents
+    this.estimatedCostInCents = estimatedCostInCents,
   }
 }
 

--- a/src/Recipe.js
+++ b/src/Recipe.js
@@ -1,3 +1,7 @@
+// const Ingredient = require('./src/Ingredient');
+const sampleData = require('../data/test-data');
+const prototypeIngredients = sampleData.sampleIngredients;
+
 class Recipe {
   constructor(id, image, ingredients, instructions, name, tags) {
     this.id = id,
@@ -12,9 +16,22 @@ class Recipe {
     return this.instructions;
   }
 
-  calculateTotalRecipeCost() {
-    // return the total cost = amount * price
-    //need an ingredient class
+  getIngredientWithPrices() {
+    let ingredientsWithPrice = prototypeIngredients.filter(ingredient => {
+     return this.ingredients.find(recipeIngredient => {
+       return   recipeIngredient.id === ingredient.id;
+     });
+    });
+    return ingredientsWithPrice;
+  }
+
+  calculateTotalCost() {
+    let estimatedIngredients = this.getIngredientWithPrices();
+    let totalCost = estimatedIngredients.reduce((total, unit, index) => {
+      return  total += unit.estimatedCostInCents * this.ingredients[index].quantity.amount;
+    }, 0);
+
+    return totalCost;
   }
 }
 

--- a/tests/Recipe-test.js
+++ b/tests/Recipe-test.js
@@ -3,6 +3,7 @@ const expect = chai.expect;
 
 const recipeCards = require('../data/test-data');
 const prototypeRecipes = recipeCards.sampleRecipes;
+const prototypeIngredients = recipeCards.sampleIngredients;
 const Recipe = require('../src/Recipe');
 
 //TODO sad path with data types
@@ -73,5 +74,20 @@ describe('Recipe', () => {
 
   it('should return instructions', () => {
     expect(recipe1.getInstructions()).to.be.equal(prototypeRecipes[0].instructions);
+  });
+
+  it('should return an array of the ingredients with prices', () => {
+    const estimatedIngredients = [
+      { id: 1, name: 'pumpkin', estimatedCostInCents: 142 },
+      { id: 2, name: 'egg nog', estimatedCostInCents: 582 },
+      { id: 3, name: 'cinnamon', estimatedCostInCents: 472 },
+      { id: 4, name: 'nutmeg', estimatedCostInCents: 582 }
+    ]
+
+    expect(recipe1.getIngredientWithPrices()).to.deep.equal(estimatedIngredients);
+  });
+
+  it('should return the total cost of the recipe', () => {
+    expect(recipe1.calculateTotalCost()).to.equal(1267);
   });
 });


### PR DESCRIPTION
## What is the change?
Created two methods in Recipe.js: etIngredientWithPrices() that gets an array from ingredients with prices and calculateTotalCost() that calculates the total cost of recipe. Two new tests were added to Recipe-test.js to test new methods.
Ingredient.js is left for the future possible use.

## What does it fix?
N/A

## Is this a fix or a feature?
Feature

## Where should the reviewer start?
ingredient.js: small changes
line 2,5

Recipe.js:
line 19-34 - two new methods

Recipe-test.js:
line 78-end - two new tests.

## How should this be tested?
By running nom tests in Recipe-test.js file would pass the last two new tests that check two new methods.